### PR TITLE
Tickets 35, 37 and a couple of bugfixes

### DIFF
--- a/app/api/v1/participant_routes.py
+++ b/app/api/v1/participant_routes.py
@@ -5,6 +5,7 @@ from app.services.participant_service import (
     leave_event,
     get_event_attendees,
     remove_participant,
+    get_attended_events,
 )
 
 router = APIRouter()
@@ -53,3 +54,14 @@ def remove_participant_api(
     Only the event organizer can perform this action.
     """
     return remove_participant(user.id, event_id, participant_id)
+
+
+@router.get("/attended/my-events")
+def get_attended_events_api(
+    user=Depends(get_current_user),
+):
+    """
+    Returns events the authenticated user has joined,
+    grouped into upcoming and past based on end_datetime.
+    """
+    return get_attended_events(user.id)

--- a/app/api/v1/participant_routes.py
+++ b/app/api/v1/participant_routes.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends
+from app.core.dependencies import get_current_user
+from app.services.participant_service import (
+    join_event,
+    leave_event,
+    get_event_attendees,
+    remove_participant,
+)
+
+router = APIRouter()
+
+
+@router.post("/{event_id}/join")
+def join_event_api(
+    event_id: str,
+    user=Depends(get_current_user),
+):
+    """Join an event. Authenticated users only."""
+    return join_event(user.id, event_id)
+
+
+@router.post("/{event_id}/leave")
+def leave_event_api(
+    event_id: str,
+    user=Depends(get_current_user),
+):
+    """Leave an event. Authenticated users only."""
+    return leave_event(user.id, event_id)
+
+
+@router.get("/{event_id}/participants")
+def get_attendees_api(
+    event_id: str,
+    user=Depends(get_current_user),
+):
+    """
+    Retrieve event attendees.
+
+    - Organizer or joined users  → full attendee list + count
+    - Everyone else              → attendee count only
+    """
+    return get_event_attendees(event_id, user.id)
+
+
+@router.delete("/{event_id}/participants/{participant_id}")
+def remove_participant_api(
+    event_id: str,
+    participant_id: str,
+    user=Depends(get_current_user),
+):
+    """
+    Remove a participant from an event.
+    Only the event organizer can perform this action.
+    """
+    return remove_participant(user.id, event_id, participant_id)

--- a/app/schemas/participant_schema.py
+++ b/app/schemas/participant_schema.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime
+
+
+class AttendeeProfile(BaseModel):
+    id: str
+    full_name: Optional[str] = None
+    avatar_url: Optional[str] = None
+
+
+class AttendeeItem(BaseModel):
+    user_id: str
+    status: str
+    created_at: Optional[datetime] = None
+    profiles: Optional[AttendeeProfile] = None
+
+
+class AttendeeListResponse(BaseModel):
+    event_id: str
+    attendee_count: int
+    # None when the requesting user has not joined and is not the organizer
+    attendees: Optional[List[AttendeeItem]] = None
+    detail: Optional[str] = None
+
+
+class RemoveParticipantResponse(BaseModel):
+    message: str
+    event_id: str
+    removed_user_id: str

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -2,45 +2,87 @@ from fastapi import HTTPException, status
 from app.db.supabase_client import supabase
 from gotrue.errors import AuthApiError
 
+
+def _email_already_registered(email: str) -> bool:
+    """Check the profiles table for an existing user with this email."""
+    response = (
+        supabase.table("profiles")
+        .select("id")
+        .eq("email", email)
+        .execute()
+    )
+    return bool(response.data)
+
+
 def register_user(email: str, password: str, full_name: str | None = None):
     try:
         response = supabase.auth.sign_up({
             "email": email,
-            "password": password
+            "password": password,
+            "options": {
+                "data": {"full_name": full_name}
+            }
         })
 
+        # Supabase returns a session-less user with an identities=[] list when
+        # the email is already registered (email confirmation flow).
+        # We treat this as a duplicate rather than silently succeeding.
+        user = response.user
+        if user and hasattr(user, "identities") and user.identities == []:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An account with this email already exists.",
+            )
+
         if response.session is None:
-            return {"message": "User registered. Please confirm email."}
+            return {"message": "User registered. Please confirm your email."}
 
         return {
             "access_token": response.session.access_token,
-            "token_type": "bearer"
+            "token_type": "bearer",
         }
 
+    except HTTPException:
+        raise
+
     except AuthApiError as e:
-        if "rate limit" in str(e).lower():
+        error_msg = str(e).lower()
+        if "rate limit" in error_msg:
             raise HTTPException(
                 status_code=429,
-                detail="Too many requests. Please try again later."
+                detail="Too many requests. Please try again later.",
             )
-        raise HTTPException(
-            status_code=400,
-            detail=str(e)
-        )
+        if "already registered" in error_msg or "already exists" in error_msg:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An account with this email already exists.",
+            )
+        raise HTTPException(status_code=400, detail=str(e))
+
 
 def login_user(email: str, password: str):
-    response = supabase.auth.sign_in_with_password({
-        "email": email,
-        "password": password
-    })
+    try:
+        response = supabase.auth.sign_in_with_password({
+            "email": email,
+            "password": password,
+        })
 
-    if response.session is None:
+        if response.session is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid credentials or email not confirmed.",
+            )
+
+        return {
+            "access_token": response.session.access_token,
+            "token_type": "bearer",
+        }
+
+    except HTTPException:
+        raise
+
+    except AuthApiError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid credentials or email not confirmed"
+            detail="Invalid credentials or email not confirmed.",
         )
-
-    return {
-        "access_token": response.session.access_token,
-        "token_type": "bearer"
-    }

--- a/app/services/participant_service.py
+++ b/app/services/participant_service.py
@@ -1,0 +1,144 @@
+from fastapi import HTTPException
+from app.db.supabase_client import supabase
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _get_event(event_id: str) -> dict:
+    """Fetch event row or raise 404."""
+    response = (
+        supabase.table("events")
+        .select("id, created_by")
+        .eq("id", event_id)
+        .single()
+        .execute()
+    )
+    if not response.data:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return response.data
+
+
+def _is_participant(user_id: str, event_id: str) -> bool:
+    """Return True if the user has an active participation row."""
+    response = (
+        supabase.table("event_participants")
+        .select("user_id")
+        .eq("user_id", user_id)
+        .eq("event_id", event_id)
+        .execute()
+    )
+    return bool(response.data)
+
+
+# ---------------------------------------------------------------------------
+# Join / Leave
+# ---------------------------------------------------------------------------
+
+def join_event(user_id: str, event_id: str):
+    event = _get_event(event_id)
+
+    if event["created_by"] == user_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Event organizers cannot join their own event.",
+        )
+
+    if _is_participant(user_id, event_id):
+        raise HTTPException(status_code=400, detail="User already joined event")
+
+    response = (
+        supabase.table("event_participants")
+        .insert({
+            "user_id": user_id,
+            "event_id": event_id,
+            "status": "going",
+        })
+        .execute()
+    )
+    return response.data
+
+
+def leave_event(user_id: str, event_id: str):
+    supabase.table("event_participants").delete().eq("user_id", user_id).eq("event_id", event_id).execute()
+    return {"message": "Left event successfully"}
+
+
+# ---------------------------------------------------------------------------
+# Get attendees  (access-controlled)
+# ---------------------------------------------------------------------------
+
+def get_event_attendees(event_id: str, requesting_user_id: str) -> dict:
+    """
+    Access rules:
+      - Organizer (created_by)  → full attendee list
+      - Joined participant      → full attendee list
+      - Everyone else           → attendee count only
+    """
+    event = _get_event(event_id)
+    is_organizer = event["created_by"] == requesting_user_id
+    is_joined = _is_participant(requesting_user_id, event_id)
+
+    # Always fetch full list — needed for count regardless of access level
+    response = (
+        supabase.table("event_participants")
+        .select("user_id, status, created_at, profiles(id, full_name, avatar_url)")
+        .eq("event_id", event_id)
+        .execute()
+    )
+    participants = response.data or []
+    count = len(participants)
+
+    if is_organizer or is_joined:
+        return {
+            "event_id": event_id,
+            "attendee_count": count,
+            "attendees": participants,
+        }
+
+    # Restricted view — count only
+    return {
+        "event_id": event_id,
+        "attendee_count": count,
+        "attendees": None,
+        "detail": "Join the event to see the full attendee list.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Remove participant  (organizer only)
+# ---------------------------------------------------------------------------
+
+def remove_participant(organizer_id: str, event_id: str, target_user_id: str) -> dict:
+    """
+    Only the event organizer (created_by) can remove a participant.
+    Deleting the row revokes the participant's event access immediately.
+    """
+    event = _get_event(event_id)
+
+    if event["created_by"] != organizer_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the event organizer can remove participants.",
+        )
+
+    if organizer_id == target_user_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Organizers cannot remove themselves. Use delete event instead.",
+        )
+
+    if not _is_participant(target_user_id, event_id):
+        raise HTTPException(
+            status_code=404,
+            detail="Participant not found in this event.",
+        )
+
+    supabase.table("event_participants").delete().eq("user_id", target_user_id).eq("event_id", event_id).execute()
+
+    return {
+        "message": "Participant removed successfully.",
+        "event_id": event_id,
+        "removed_user_id": target_user_id,
+    }

--- a/app/services/participant_service.py
+++ b/app/services/participant_service.py
@@ -1,4 +1,5 @@
 from fastapi import HTTPException
+from datetime import datetime, timezone
 from app.db.supabase_client import supabase
 
 
@@ -141,4 +142,80 @@ def remove_participant(organizer_id: str, event_id: str, target_user_id: str) ->
         "message": "Participant removed successfully.",
         "event_id": event_id,
         "removed_user_id": target_user_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Get attended events  (upcoming / past)
+# ---------------------------------------------------------------------------
+
+def get_attended_events(user_id: str) -> dict:
+    """
+    Returns events the user has joined via event_participants,
+    split into upcoming and past based on whether end_datetime has passed.
+    Does not include events the user created.
+    """
+    # Fetch all participation rows with full event data for this user
+    response = (
+        supabase.table("event_participants")
+        .select(
+            "status, created_at, "
+            "events(id, title, description, category, cost, max_capacity, status, "
+            "start_datetime, end_datetime, location_name, latitude, longitude, "
+            "created_by, created_at, updated_at)"
+        )
+        .eq("user_id", user_id)
+        .execute()
+    )
+
+    rows = response.data or []
+    now = datetime.now(timezone.utc)
+
+    upcoming = []
+    past = []
+
+    for row in rows:
+        event = row.get("events")
+        if not event:
+            continue
+
+        # Skip cancelled events
+        if event.get("status") == "cancelled":
+            continue
+
+        # Parse end_datetime — Supabase returns ISO strings with tz info
+        end_str = event.get("end_datetime")
+        if not end_str:
+            continue
+
+        try:
+            end_dt = datetime.fromisoformat(end_str)
+            # Ensure tz-aware for comparison
+            if end_dt.tzinfo is None:
+                end_dt = end_dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+
+        # Attach participation metadata to the event payload
+        event["participation_status"] = row.get("status")
+        event["joined_at"] = row.get("created_at")
+
+        if end_dt > now:
+            upcoming.append(event)
+        else:
+            past.append(event)
+
+    # Upcoming: soonest first; Past: most recent first
+    upcoming.sort(key=lambda e: e["end_datetime"])
+    past.sort(key=lambda e: e["end_datetime"], reverse=True)
+
+    return {
+        "upcoming": {
+            "total_count": len(upcoming),
+            "data": upcoming,
+        },
+        "past": {
+            "total_count": len(past),
+            "data": past,
+        },
     }


### PR DESCRIPTION
## 📝 Summary

This PR implements backend support for two tickets:

**Ticket 1 - Event Attendee Viewing & Organizer Removal**
- Added `GET /{event_id}/participants` - returns the full attendee list for the event organizer or joined participants, and attendee count only for everyone else
- Added `DELETE /{event_id}/participants/{participant_id}` - allows the event organizer to remove a participant, immediately revoking their event access

**Ticket 2 - Attended Events (My Events)**
- Added `GET /attended/my-events` — returns events the authenticated user has joined, split into `upcoming` and `past` groups based on `end_datetime`
- Upcoming events are sorted soonest-first; past events are sorted most-recent-first
- Each event includes `participation_status` and `joined_at` metadata for frontend use
- Cancelled events are excluded from both groups

**Bugfixes - 
- Prevented event organizers from joining their own events
- Added duplicate registration protection to `auth_service.py` — detects already-registered emails via Supabase's `identities == []` pattern and returns a clean `409 Conflict`


**Files changed:**
- `app/services/participant_service.py`
- `app/api/v1/participant_routes.py`
- `app/schemas/participant_schema.py`
- `app/services/auth_service.py`

## 🔗 Related Issue

Closes #35
Closes #37 

## ✅ Checklist for Reviewers

- [x] Code follows our style guide.
- [] I have tested this locally.
- [] No new console warnings/errors.