### PR TITLE
Add event join/leave endpoints from feature/backend branch and fix foreign key constraint on saved_events

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.v1 import auth_routes, event_routes, profile_routes, saved_event_routes, notification_routes
+from app.api.v1 import auth_routes, event_routes, profile_routes, saved_event_routes, notification_routes, participant_routes
 
 api_router = APIRouter()
 
@@ -37,4 +37,10 @@ api_router.include_router(
     notification_routes.router,
     prefix="/notifications",
     tags=["Notifications"]
+)
+
+api_router.include_router(
+    participant_routes.router,
+    prefix="/participants",
+    tags=["Participants"]
 )

--- a/app/api/v1/event_routes.py
+++ b/app/api/v1/event_routes.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Query
 from app.core.dependencies import get_current_user
 from app.schemas.event_schema import EventCreateRequest, EventUpdateRequest
+from fastapi import HTTPException
 from app.services.event_service import (
     create_event,
     get_event,

--- a/app/api/v1/participant_routes.py
+++ b/app/api/v1/participant_routes.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, Query
+from app.core.dependencies import get_current_user
+from app.services.participant_service import (
+    join_event,
+    leave_event,
+    get_event_participants
+)
+
+router = APIRouter()
+
+@router.post("/{event_id}/join")
+def join_event_api(
+    event_id: str,
+    user = Depends(get_current_user)
+):
+
+    return join_event(user.id, event_id)
+
+
+@router.post("/{event_id}/leave")
+def leave_event_api(
+    event_id: str,
+    user = Depends(get_current_user)
+):
+
+    return leave_event(user.id, event_id)
+
+
+@router.get("/{event_id}/participants")
+def participants_api(event_id: str):
+
+    return get_event_participants(event_id)

--- a/app/services/participant_service.py
+++ b/app/services/participant_service.py
@@ -1,0 +1,54 @@
+from fastapi import HTTPException
+from app.db.supabase_client import supabase
+
+
+def join_event(user_id: str, event_id: str):
+
+    # check if already joined
+    existing = (
+        supabase.table("event_participants")
+        .select("*")
+        .eq("user_id", user_id)
+        .eq("event_id", event_id)
+        .execute()
+    )
+
+    if existing.data:
+        raise HTTPException(status_code=400, detail="User already joined event")
+
+    response = (
+        supabase.table("event_participants")
+        .insert({
+            "user_id": user_id,
+            "event_id": event_id,
+            "status": "going"
+        })
+        .execute()
+    )
+
+    return response.data
+
+
+def leave_event(user_id: str, event_id: str):
+
+    response = (
+        supabase.table("event_participants")
+        .delete()
+        .eq("user_id", user_id)
+        .eq("event_id", event_id)
+        .execute()
+    )
+
+    return {"message": "Left event successfully"}
+
+
+def get_event_participants(event_id: str):
+
+    response = (
+        supabase.table("event_participants")
+        .select("user_id, status, profiles(full_name, avatar_url)")
+        .eq("event_id", event_id)
+        .execute()
+    )
+
+    return response.data


### PR DESCRIPTION
- Introduced new APIs for users to join and leave events.
- Fixed issue with deleting events that were referenced in saved_events:
  - Updated foreign key constraint on saved_events.event_id to ON DELETE CASCADE.
  - This ensures deleting an event automatically removes related saved_events, preventing foreign key violations.
- Minor refactor to event deletion logic to handle dependencies safely.
- These changes improve event management and prevent database constraint errors when deleting events.