### PR TITLE
Add profile interest embeddings feature

### DIFF
--- a/app/schemas/profile_schema.py
+++ b/app/schemas/profile_schema.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 
 
 class ProfileResponse(BaseModel):
@@ -8,6 +8,7 @@ class ProfileResponse(BaseModel):
     phone: Optional[str]
     avatar_url: Optional[str]
     bio: Optional[str]
+    interests: Optional[List[str]] = None
     visibility: Optional[str]
     latitude: Optional[float]
     longitude: Optional[float]
@@ -18,6 +19,7 @@ class ProfileUpdateRequest(BaseModel):
     phone: Optional[str] = None
     avatar_url: Optional[str] = None
     bio: Optional[str] = None
+    interests: Optional[List[str]] = None
     visibility: Optional[str] = None
 
 

--- a/app/services/profile_service.py
+++ b/app/services/profile_service.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from fastapi import HTTPException, status
 from app.db.supabase_client import supabase
+from app.utils.embedding_helper import generate_embedding
 
 
 def get_profile(user_id: str):
@@ -22,9 +23,36 @@ def get_profile(user_id: str):
     return response.data
 
 
+def _compute_interest_embedding(interests: list[str] | None, bio: str | None) -> list[float] | None:
+    interests = interests or []
+    bio = bio or ""
+    text = (" ".join(interests) + " " + bio).strip()
+    return generate_embedding(text) if text else None
+
+
 def update_profile(user_id: str, update_data: dict):
     """Update profile fields for the authenticated user."""
     update_data["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    # If the user updates interests and/or bio, regenerate the interest embedding.
+    # We fetch the existing profile so partial updates still produce a correct embedding.
+    if "interests" in update_data or "bio" in update_data:
+        existing = (
+            supabase.table("profiles")
+            .select("interests, bio")
+            .eq("id", user_id)
+            .single()
+            .execute()
+        )
+        if existing.data is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
+
+        interests = update_data.get("interests", existing.data.get("interests"))
+        bio = update_data.get("bio", existing.data.get("bio"))
+        update_data["interest_embedding"] = _compute_interest_embedding(interests, bio)
 
     response = (
         supabase.table("profiles")

--- a/tests/test_profile_service.py
+++ b/tests/test_profile_service.py
@@ -52,6 +52,34 @@ class TestUpdateProfile:
         args = chain.update.call_args[0][0]
         assert "updated_at" in args
 
+    @patch("app.services.profile_service.generate_embedding")
+    @patch("app.services.profile_service.supabase")
+    def test_update_interests_regenerates_embedding(self, mock_sb, mock_generate):
+        mock_generate.return_value = [0.1, 0.2, 0.3]
+
+        # first query: fetch existing interests/bio for partial update embedding compute
+        select_chain = MagicMock()
+        update_chain = MagicMock()
+
+        mock_sb.table.side_effect = [select_chain, update_chain]
+        select_chain.select.return_value = select_chain
+        select_chain.eq.return_value = select_chain
+        select_chain.single.return_value = select_chain
+        select_chain.execute.return_value = MagicMock(data={"interests": ["old"], "bio": "Old bio"})
+
+        # second query: actual update call
+        update_chain.update.return_value = update_chain
+        update_chain.eq.return_value = update_chain
+        update_chain.execute.return_value = MagicMock(data=[{"id": "u1"}])
+
+        from app.services.profile_service import update_profile
+        update_profile("u1", {"interests": ["sports", "photography"]})
+
+        payload = update_chain.update.call_args[0][0]
+        assert payload["interests"] == ["sports", "photography"]
+        assert payload["interest_embedding"] == [0.1, 0.2, 0.3]
+        mock_generate.assert_called_once()
+
     @patch("app.services.profile_service.supabase")
     def test_update_failure_raises_400(self, mock_sb):
         chain = MagicMock()


### PR DESCRIPTION
- Adds user interests support to the Profile service (PUT /profile/me) via ProfileUpdateRequest.
- Automatically generates/refreshes interest_embedding whenever interests or bio is created/updated, and persists it to the profiles table.