### PR TITLE
Replacing user_id with user name in app notifications

### DIFF
--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -4,6 +4,7 @@ from app.db.supabase_client import supabase
 from app.utils.embedding_helper import generate_embedding
 from app.services.notification_service import create_notification
 from app.services.chat_service import post_system_notification
+from app.services.profile_service import get_display_name
 import logging
 
 logger = logging.getLogger(__name__)
@@ -229,11 +230,13 @@ def update_event(user_id: str, event_id: str, update_data: dict):
 
     print("Participants:", participants.data)
 
+    display_name = get_display_name(user_id)
+
     create_notification(
         user_id,
         event_id,
         "event_updated",
-        f"Event '{event['title']}' was updated by {user_id}"
+        f"Event '{event['title']}' was updated by {display_name}"
     )
 
     for p in participants.data:
@@ -245,7 +248,7 @@ def update_event(user_id: str, event_id: str, update_data: dict):
             p["user_id"],
             event_id,
             "event_updated",
-            f"Event '{event['title']}' was updated by {user_id}"
+            f"Event '{event['title']}' was updated by {display_name}"
         )
 
     # Send update emails to all participants using the full merged event data
@@ -272,12 +275,13 @@ def delete_event(user_id: str, event_id: str):
     if delete_response.data:
         # Send cancellation emails before notifying
         _email_participants(event, "cancellation")
+        display_name = get_display_name(user_id)
         for p in participants.data:
             create_notification(
                 p["user_id"],
                 event_id,
                 "event_deleted",
-                f"Event '{event['title']}' was deleted by {user_id}"
+                f"Event '{event['title']}' was deleted by {display_name}"
             )
     return {"message": "Event deleted successfully"}
 
@@ -408,13 +412,15 @@ def cancel_event(user_id: str, event_id: str):
 
     # notify
     from app.services.notification_service import create_notification
+    
+    display_name = get_display_name(user_id)
 
     for p in participants.data:
         create_notification(
             p["user_id"],
             event_id,
             "event_cancelled",
-            f"Event '{event['title']}' was cancelled by {user_id}"
+            f"Event '{event['title']}' was cancelled by {display_name}"
         )
 
     return {"message": "Event cancelled"}

--- a/app/services/participant_service.py
+++ b/app/services/participant_service.py
@@ -6,20 +6,7 @@ from app.services.event_service import get_event
 from app.services.chat_service import post_system_notification
 
 
-def _get_display_name(user_id: str) -> str:
-    """Return the user's full_name from profiles, falling back to a short ID."""
-    try:
-        result = (
-            supabase.table("profiles")
-            .select("full_name")
-            .eq("id", user_id)
-            .single()
-            .execute()
-        )
-        name = result.data.get("full_name") if result.data else None
-        return name if name else user_id[:8]
-    except Exception:
-        return user_id[:8]
+from app.services.profile_service import get_display_name
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +53,7 @@ def join_event(user_id: str, event_id: str):
     )
 
     # Post system notification in the event chat
-    display_name = _get_display_name(user_id)
+    display_name = get_display_name(user_id)
     post_system_notification(event_id, f"👋 {display_name} has joined this chat")
 
     # Notify organizer

--- a/app/services/profile_service.py
+++ b/app/services/profile_service.py
@@ -23,6 +23,25 @@ def get_profile(user_id: str):
     return response.data
 
 
+def get_display_name(user_id: str) -> str:
+    """Return the user's full_name from profiles, falling back to 'Someone' if empty."""
+    try:
+        result = (
+            supabase.table("profiles")
+            .select("full_name")
+            .eq("id", user_id)
+            .single()
+            .execute()
+        )
+        name = result.data.get("full_name") if result.data else None
+        # if the name is strictly empty or whitespace, treat as missing
+        if name and name.strip():
+            return name.strip()
+        return "Someone"
+    except Exception:
+        return "Someone"
+
+
 def _compute_interest_embedding(interests: list[str] | None, bio: str | None) -> list[float] | None:
     interests = interests or []
     bio = bio or ""


### PR DESCRIPTION
This PR resolves an issue where system-generated event notifications (such as updates, deletions, and cancellations) were injecting the actor's raw database UUID into the notification message instead of their actual name.