### PR TITLE
feat(auth): implement password reset flow and password reuse validation

### DIFF
--- a/app/api/v1/auth_routes.py
+++ b/app/api/v1/auth_routes.py
@@ -3,9 +3,9 @@ from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, EmailStr
 from supabase import create_client, Client
 
-from app.schemas.auth_schema import RegisterRequest, LoginRequest
+from app.schemas.auth_schema import RegisterRequest, LoginRequest, ChangePasswordRequest
 # Removed 'reset_password' from the import below to prevent function name collisions
-from app.services.auth_service import register_user, login_user, request_password_reset
+from app.services.auth_service import register_user, login_user, request_password_reset, change_password
 from app.core.dependencies import get_current_user
 import httpx
 
@@ -66,40 +66,18 @@ def forgot_password(body: PasswordResetRequestBody):
 
 
 @router.post("/reset-password")
-async def update_user_password(payload: ResetPasswordPayload):
-    if not SUPABASE_URL or not SUPABASE_SERVICE_KEY:
-        raise HTTPException(status_code=500, detail="Missing Supabase Env Vars")
+def update_user_password(payload: ResetPasswordPayload):
+    return reset_password(
+        access_token=payload.access_token,
+        new_password=payload.new_password
+    )
 
-    try:
-        # Step 1: Verify the user token using the standard client
-        user_response = supabase.auth.get_user(payload.access_token)
-        if not user_response.user:
-            raise HTTPException(status_code=401, detail="Invalid token")
 
-        # Step 2: Direct REST API Call (Bypasses the python library entirely)
-        # This forces Supabase to recognize the Admin privileges.
-        url = f"{SUPABASE_URL}/auth/v1/admin/users/{user_response.user.id}"
-        
-        headers = {
-            "apikey": SUPABASE_SERVICE_KEY,
-            "Authorization": f"Bearer {SUPABASE_SERVICE_KEY}", # MUST be the Service Key here
-            "Content-Type": "application/json"
-        }
-        
-        data = {
-            "password": payload.new_password
-        }
-
-        # Make the request to force the password change
-        async with httpx.AsyncClient() as client:
-            response = await client.put(url, headers=headers, json=data)
-
-        # Catch specific errors from the REST API
-        if response.status_code != 200:
-            error_msg = response.json().get("msg", response.text)
-            raise HTTPException(status_code=400, detail=f"Admin Update Failed: {error_msg}")
-
-        return {"message": "Password updated successfully."}
-
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Auth Error: {str(e)}")
+@router.post("/change-password")
+def change_user_password(data: ChangePasswordRequest, user=Depends(get_current_user)):
+    return change_password(
+        email=user.email,
+        user_id=user.id,
+        current_password=data.current_password,
+        new_password=data.new_password
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,23 +2,30 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from pydantic_settings import BaseSettings
+from pydantic import ConfigDict
 from typing import Optional
 
+
 class Settings(BaseSettings):
+    model_config = ConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="ignore",
+    )
+
     PROJECT_NAME: str = "E-VENT Orchestrator"
-    
-    # Existing required fields
+
+    # Required fields
     DATABASE_URL: str
     SUPABASE_URL: str
     SUPABASE_SERVICE_KEY: str
-    SUPABASE_ANON_KEY: str
+    SUPABASE_ANON_KEY: Optional[str] = None
 
-    # Add these missing fields to match your .env
     SUPABASE_JWT_SECRET: str
     BACKEND_URL: str
     FRONTEND_URL: str
-    
-    # Optional: If you have the Mixedbread key in .env, add it here too
+
+    # Optional extras
     MXBAI_API_KEY: Optional[str] = None
 
     # Email / SMTP settings
@@ -28,14 +35,7 @@ class Settings(BaseSettings):
     SMTP_PASSWORD: Optional[str] = None
     EMAIL_FROM: str = "no-reply@eventapp.com"
 
-    # Cron job secret (used to protect the /reminders/trigger endpoint)
     CRON_SECRET: Optional[str] = None
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
-        # This prevents the "extra_forbidden" error by ignoring 
-        # any .env variables not defined above.
-        extra = "ignore" 
 
 settings = Settings()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     DATABASE_URL: str
     SUPABASE_URL: str
     SUPABASE_SERVICE_KEY: str
+    SUPABASE_ANON_KEY: str
 
     # Add these missing fields to match your .env
     SUPABASE_JWT_SECRET: str

--- a/app/schemas/auth_schema.py
+++ b/app/schemas/auth_schema.py
@@ -21,3 +21,7 @@ class LoginRequest(BaseModel):
 class AuthResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -3,6 +3,8 @@ from openai import APIError
 from app.db.supabase_client import supabase
 from gotrue.errors import AuthApiError
 from app.utils.embedding_helper import generate_embedding
+from app.core.config import settings
+
 
 def register_user(
     email: str, 
@@ -118,26 +120,98 @@ def login_user(email: str, password: str):
         )
 
 def request_password_reset(email: str):
+    """
+    Step 1: Validate email exists + send reset email
+    """
+
     try:
-        supabase.auth.reset_password_email(email)
-        return {"message": "If an account exists with that email, a reset link has been sent."}
+        # Try sending reset email (Supabase handles existence internally)
+        supabase.auth.reset_password_email(
+            email,
+            {
+                "redirect_to": f"{settings.FRONTEND_URL}/reset-password"
+            }
+        )
+
+        return {"message": "Password reset email sent."}
+
     except AuthApiError as e:
-        raise HTTPException(status_code=400, detail=f"Auth Error: {str(e)}")
+        error_msg = str(e).lower()
+
+        if "user not found" in error_msg:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Email not registered."
+            )
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Auth Error: {str(e)}"
+        )
 
 
 def reset_password(access_token: str, new_password: str):
-    try:
-        # Verify the token and get the user
-        user_response = supabase.auth.get_user(access_token)
-        if not user_response.user:
-            raise HTTPException(status_code=401, detail="Invalid or expired reset token")
+    """
+    Step 2: Validate token + update password
+    """
 
-        # Use admin client to update password directly — no session needed
+    try:
+        # Validate token
+        user_response = supabase.auth.get_user(access_token)
+
+        if not user_response.user:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired reset link."
+            )
+
+        # Update password using admin privileges
         supabase.auth.admin.update_user_by_id(
             user_response.user.id,
+            {"password": new_password}
+        )
+
+        return {"message": "Password updated successfully."}
+
+    except AuthApiError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired reset link."
+        )
+
+def change_password(email: str, user_id: str, current_password: str, new_password: str):
+    if current_password == new_password:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New password cannot be the same as the previous/current password."
+        )
+
+    try:
+        # Verify the current password by trying to log in
+        verify_response = supabase.auth.sign_in_with_password({
+            "email": email,
+            "password": current_password
+        })
+
+        if verify_response.session is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Incorrect current password."
+            )
+
+        # Proceed to update the password using the admin client
+        # as it allows direct modification by ID and avoids session issues in the python client
+        supabase.auth.admin.update_user_by_id(
+            user_id,
             {"password": new_password}
         )
         return {"message": "Password updated successfully."}
 
     except AuthApiError as e:
+        error = str(e).lower()
+        if "invalid login credentials" in error:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Incorrect current password."
+            )
         raise HTTPException(status_code=400, detail=f"Auth Error: {str(e)}")

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -35,3 +35,46 @@ class TestAuthRoutes:
         
         assert response.status_code == 200
         assert response.json()["access_token"] == "token"
+
+    @patch("app.api.v1.auth_routes.change_password")
+    def test_change_password_route(self, mock_change_password):
+        class MockUser:
+            id = "u1"
+            email = "test@test.com"
+            
+        def override_get_current_user():
+            return MockUser()
+            
+        from app.core.dependencies import get_current_user
+        app.dependency_overrides[get_current_user] = override_get_current_user
+        
+        try:
+            mock_change_password.return_value = {"message": "Password updated successfully."}
+            
+            response = client.post("/api/auth/change-password", json={
+                "current_password": "password123",
+                "new_password": "password456"
+            }, headers={"Authorization": "Bearer token"})
+            
+            assert response.status_code == 200
+            assert response.json()["message"] == "Password updated successfully."
+            mock_change_password.assert_called_once_with(
+                email="test@test.com",
+                user_id="u1",
+                current_password="password123",
+                new_password="password456"
+            )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+
+    @patch("app.api.v1.auth_routes.request_password_reset")
+    def test_forgot_password_route(self, mock_forgot_password):
+        mock_forgot_password.return_value = {"message": "Password reset email sent."}
+        
+        response = client.post("/api/auth/forgot-password", json={
+            "email": "test@test.com"
+        })
+        
+        assert response.status_code == 200
+        assert response.json()["message"] == "Password reset email sent."
+        mock_forgot_password.assert_called_once_with("test@test.com")

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -136,3 +136,38 @@ class TestLoginUser:
         with pytest.raises(HTTPException) as exc:
             login_user("a@b.com", "wrong")
         assert exc.value.status_code == 401
+
+# ──────────────────────────────────────────────
+# change_password
+# ──────────────────────────────────────────────
+
+class TestChangePassword:
+    def test_change_password_same_password_raises_400(self):
+        from app.services.auth_service import change_password
+        with pytest.raises(HTTPException) as exc:
+            change_password("test@test.com", "u1", "samepass", "samepass")
+        assert exc.value.status_code == 400
+        assert "cannot be the same" in exc.value.detail.lower()
+
+    @patch("app.services.auth_service.supabase")
+    def test_change_password_invalid_current_password_raises_401(self, mock_sb):
+        from app.services.auth_service import change_password
+        mock_sb.auth.sign_in_with_password.return_value = MagicMock(session=None)
+        
+        with pytest.raises(HTTPException) as exc:
+            change_password("test@test.com", "u1", "wrong", "newpass")
+        assert exc.value.status_code == 401
+        assert "incorrect current password" in exc.value.detail.lower()
+
+    @patch("app.services.auth_service.supabase")
+    def test_change_password_success(self, mock_sb):
+        from app.services.auth_service import change_password
+        mock_sb.auth.sign_in_with_password.return_value = MagicMock(session="valid_session")
+        
+        result = change_password("test@test.com", "u1", "correct", "newpass")
+        
+        assert result["message"] == "Password updated successfully."
+        mock_sb.auth.admin.update_user_by_id.assert_called_once_with(
+            "u1",
+            {"password": "newpass"}
+        )


### PR DESCRIPTION
Implements password reset flow and enforces password reuse restriction.

- Added forgot password endpoint
- Implemented reset password with token validation
- Prevented reuse of current password
- Added error handling for invalid/expired tokens

Tickets:
- #69
- #99