### PR TITLE
Checking Existing User State, Raising HTTP 409, Adding Unit Tests

### DIFF
--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -28,6 +28,9 @@ def register_user(
         if not auth_response.user:
             raise HTTPException(status_code=400, detail="Registration failed")
 
+        if auth_response.user.identities is not None and len(auth_response.user.identities) == 0:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already exists")
+
         user_id = auth_response.user.id
 
         # Generate interest embedding

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -31,6 +31,7 @@ class TestRegisterUser:
     def _make_auth_response(self, user_id="uid-1", with_session=True):
         user = MagicMock()
         user.id = user_id
+        user.identities = ["identity"]
         session = MagicMock()
         session.access_token = "tok-abc"
         resp = MagicMock()
@@ -105,6 +106,19 @@ class TestRegisterUser:
             register_user("young@b.com", "pass", "2010-01-01", "M", [])
         assert exc.value.status_code == 400
         assert "18 or older" in exc.value.detail
+
+    @patch("app.services.auth_service.supabase")
+    def test_register_existing_user_raises_409(self, mock_sb):
+        resp = MagicMock()
+        resp.user = MagicMock()
+        resp.user.identities = []  # Empty identities indicates user already exists
+        mock_sb.auth.sign_up.return_value = resp
+
+        from app.services.auth_service import register_user
+        with pytest.raises(HTTPException) as exc:
+            register_user("existing@b.com", "pass", "2000-01-01", "M", [])
+        assert exc.value.status_code == 409
+        assert "User already exists" in exc.value.detail
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
### Summary

Updated the registration flow to properly detect and prevent duplicate user registrations when using Supabase authentication.

### Changes

* Added validation in `register_user` to detect existing users based on Supabase `sign_up` response behavior.
* Implemented handling for Supabase Email Enumerability Protection, where duplicate sign-up attempts return a fake user object with empty `identities`.
* Added explicit `HTTP 409 CONFLICT` response with message:

  * `"User already exists"`
* Prevented duplicate profile creation in the `profiles` table.
* Added unit test coverage for duplicate registration scenarios.
* Updated existing mock tests to include valid identities for successful registration paths.

### Files Updated

* `app/services/auth_service.py`
* `tests/test_auth_service.py`

